### PR TITLE
Add "Safari Assistant" workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A curated list of Awesome Alfred Workflows.
 ## Web
 - [BugNot](https://github.com/vitorgalvao/alfred-workflows/tree/master/BugNot) - Get logins from bugmenot.
 - [IncognitoClone](https://github.com/vitorgalvao/alfred-workflows/tree/master/IncognitoClone) - Opens Chrome’s frontmost tab in an incognito window.
+- [Safari Assistant](https://github.com/deanishe/alfred-safari-assistant) - Browse, open & manipulate Safari bookmarks, history and tabs. Customizable with your own scripts.
 - [TemporaryEmail](https://github.com/vitorgalvao/alfred-workflows/tree/master/TemporaryEmail) - Get a temporary email inbox from Teleosaurs Mail.
 
 ## Helpers


### PR DESCRIPTION
I've added it to the "Web" category, but there seems to be some disagreement over where such workflows belong: `IncognitoClone` is in "Web", but `Safari History Search` is in "System".

Where *do* such workflows belong?